### PR TITLE
New transformer formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,11 @@ This repository contains transformers for creating custom Praise exports and tok
 
 Paste the url of the raw transformer file into the Custom Exports tab of the Praise settings to use.
 
-Praise custom exports use a slightly modified version of [node-json-transform](https://github.com/bozzltron/node-json-transform).
+For full reference on the transformer map format, see [ses-node-json-transform](https://github.com/kristoferlund/ses-node-json-transform).
 
 ## Transformer Schema
 
 ```javascript
-interface ExportTransformerOperateItem {
-  run: string;
-  on: string;
-}
-
 interface ExportTransformerMap {
   name: string;
   map: {
@@ -25,13 +20,37 @@ interface ExportTransformerMap {
   filterColumn: string;
   includeCsvHeaderRow?: boolean;
 }
+
+interface ExportTransformerOperateItem {
+  run: string;
+  on: string;
+}
 ```
+
+### ExportTransformerOperateItem
+
+`run` accepts a string with a function to be evaluated.
+
+- The function must return a value.
+- Function accepts two parameters: `val` and `context`.
+- Example: `(val) => val.toUpperCase()`;
+
+`on` accepts a string of the name of the property to run the function on.
 
 ## Input data
 
 Each item processed by the transformer contain the following info:
 
 ```javascript
+interface PeriodDetailsGiverReceiverDto {
+  _id: string;
+  praiseCount: number;
+  identityEthAddress?: string;
+  rewardsEthAddress?: string;
+  scoreRealized: number;
+  userAccount: UserAccountDto;
+}
+
 interface UserAccountDto {
   _id: string;
   user?: string;
@@ -40,14 +59,6 @@ interface UserAccountDto {
   nameRealized: string; // Jim
   avatarId?: string;
   platform: string; // 'DISCORD'
-}
-
-interface PeriodDetailsGiverReceiverDto {
-  _id: string;
-  praiseCount: number;
-  ethereumAddress?: string;
-  scoreRealized: number;
-  userAccount: UserAccountDto;
 }
 ```
 
@@ -58,4 +69,12 @@ In addition to the context parameters defined in the transformer and praise sett
 ```javascript
 praiseItemsCount: number; // Total number of praise items in the period
 totalPraiseScore: number; // Total praise score in the period
+```
+
+## Globals
+
+Since the transformers are evaluated in a secure sandbox, only the following globals are available:
+
+```
+Math
 ```

--- a/aragon-fixed-budget/transformer.json
+++ b/aragon-fixed-budget/transformer.json
@@ -2,21 +2,20 @@
   "name": "Aragon fixed budget",
   "map": {
     "item": {
-      "address": "ethereumAddress",
+      "address": "rewardsEthAddress",
       "amount": "scoreRealized",
       "token": ""
     },
     "operate": [
       {
-        "run": "(item.amount / totalPraiseScore) * budget",
+        "run": "(val, context) => (val / context.totalPraiseScore * context.budget)",
         "on": "amount"
       },
       {
-        "run": "token",
+        "run": "(val, context) => context.token",
         "on": "token"
       }
-    ],
-    "each": "item"
+    ]
   },
   "context": {
     "budget": "number",

--- a/aragon-straight-curve-with-ceiling/transformer.json
+++ b/aragon-straight-curve-with-ceiling/transformer.json
@@ -2,21 +2,20 @@
   "name": "Aragon, Straight Curve with Ceiling",
   "map": {
     "item": {
-      "address": "ethereumAddress",
+      "address": "rewardsEthAddress",
       "amount": "scoreRealized",
       "token": ""
     },
     "operate": [
       {
-        "run": "((item, cutoff, ceiling, praiseItemsCount, totalPraiseScore) => { const budget = praiseItemsCount > cutoff ? ceiling : praiseItemsCount / cutoff * ceiling; return (item.amount / totalPraiseScore) * budget; })(item, cutoff, ceiling, praiseItemsCount, totalPraiseScore)",
+        "run": "(val, context) => { const budget = context.praiseItemsCount > context.cutoff ? context.ceiling : context.praiseItemsCount / context.cutoff * context.ceiling; return (val / context.totalPraiseScore) * budget; }",
         "on": "amount"
       },
       {
-        "run": "token",
+        "run": "(val, context) => context.token",
         "on": "token"
       }
-    ],
-    "each": "item"
+    ]
   },
   "context": {
     "ceiling": "number",

--- a/safe-straight-curve-with-ceiling/transformer.json
+++ b/safe-straight-curve-with-ceiling/transformer.json
@@ -4,25 +4,24 @@
     "item": {
       "token_type": "",
       "token_address": "",
-      "receiver": "ethereumAddress",
+      "receiver": "rewardsEthAddress",
       "amount": "scoreRealized",
       "id": ""
     },
     "operate": [
       {
-        "run": "tokenType",
+        "run": "(val, context) => context.tokenType",
         "on": "token_type"
       },
       {
-        "run": "tokenAddress",
+        "run": "(val, context) => context.tokenAddress",
         "on": "token_address"
       },
       {
-        "run": "((item, cutoff, ceiling, praiseItemsCount, totalPraiseScore) => { const budget = praiseItemsCount > cutoff ? ceiling : praiseItemsCount / cutoff * ceiling; return (item.amount / totalPraiseScore) * budget; })(item, cutoff, ceiling, praiseItemsCount, totalPraiseScore)",
+        "run": "(val, context) => { const budget = context.praiseItemsCount > context.cutoff ? context.ceiling : context.praiseItemsCount / context.cutoff * context.ceiling; return (val / context.totalPraiseScore) * budget; }",
         "on": "amount"
       }
-    ],
-    "each": "item"
+    ]
   },
   "context": {
     "ceiling": "number",
@@ -31,5 +30,5 @@
     "tokenAddress": "string"
   },
   "filterColumn": "receiver",
-  "includeCsvHeaderRow": false
+  "includeCsvHeaderRow": true
 }


### PR DESCRIPTION
All transformers have been migrated to a slightle new format because of the switch to using [ses-node-json-transform](https://github.com/kristoferlund/ses-node-json-transform) for evalutaing untrusted code.